### PR TITLE
Fix warnings

### DIFF
--- a/R/PullCatch.fn.R
+++ b/R/PullCatch.fn.R
@@ -262,9 +262,19 @@ PullCatch.fn <- function(Name = NULL, SciName = NULL, YearRange = c(1980, 5000),
       stringsAsFactors = FALSE
     )
   }
-  Out <- dplyr::left_join(grid, All.Tows)
-  Out <- dplyr::left_join(Out, Data)
-  # Out = dplyr::left_join(All.Tows, Data)
+
+  Out <- dplyr::left_join(
+    grid,
+    All.Tows,
+    by = intersect(colnames(grid), colnames(All.Tows)),
+    multiple = "all"
+  )
+  Out <- dplyr::left_join(
+    Out,
+    Data,
+    by = intersect(colnames(Out), colnames(Data)),
+    multiple = "all"
+  )
 
   # Fill in zeros where needed
   Out$total_catch_wt_kg[is.na(Out$total_catch_wt_kg)] <- 0

--- a/R/plot_proportion.R
+++ b/R/plot_proportion.R
@@ -212,16 +212,16 @@ wh_plot_proportion <- function(data_catch,
   # rerun repeats the augmented data frame .n times
   data <- c(
     if (!missing(data_catch)) {
-      dplyr::mutate(data_catch, the_factor = factor(
-        cpue_kg_km2 <= 0,
-        levels = c(FALSE, TRUE),
-        labels = c("Present", "Absent")
-      )) %>%
-        purrr::rerun(.n = 2)
+      1:2 %>%
+        purrr::map(\(i) dplyr::mutate(data_catch, the_factor = factor(
+          cpue_kg_km2 <= 0,
+          levels = c(FALSE, TRUE),
+          labels = c("Present", "Absent")
+        )))
     },
     if (!missing(data_bio)) {
-      dplyr::mutate(data_bio, the_factor = codify_sex(Sex)) %>%
-        purrr::rerun(.n = 2)
+      1:2 %>%
+        purrr::map(\(i) dplyr::mutate(data_bio, the_factor = codify_sex(Sex)))
     }
   )
 

--- a/R/pull_catch.R
+++ b/R/pull_catch.R
@@ -215,8 +215,18 @@ pull_catch <- function(common_name = NULL,
     )    
   }
 
-  catch_data <- dplyr::left_join(grid, all_tows)
-  catch <- dplyr::left_join(catch_data, positive_tows)
+  catch_data <- dplyr::left_join(
+    grid,
+    all_tows,
+    by = intersect(colnames(grid), colnames(all_tows)),
+    multiple = "all"
+  )
+  catch <- dplyr::left_join(
+    catch_data,
+    positive_tows,
+    by = intersect(colnames(catch_data), colnames(positive_tows)),
+    multiple = "all"
+  )
 
   # Need to check what this is doing
   no_area <- which(is.na(catch$area_swept_ha_der))


### PR DESCRIPTION
Fix warnings generated in test-data and test-wh_proportion. As well as remove the message from `dplyr::left_join()` regarding the by columns.