### PR TITLE
Update plotBioStrata.fn.R to Handle Single Strata

### DIFF
--- a/R/plotBioStrata.fn.R
+++ b/R/plotBioStrata.fn.R
@@ -56,13 +56,16 @@ PlotBioStrata.fn <- function(dir = NULL, dat, CI = 0.95, scalar = 1e6, gap = 0.0
   }
 
   if (is.null(strata.names)) {
-    strata.names <- names(bio_strat)
+      strata.names <- names(bio_strat)
+      if(length(strata.names) == 1){
+        strata.names[1] <- ""
+      }
   }
 
   if (!is.null(mfrow.in)) {
     par(mfrow = c(mfrow.in[1], mfrow.in[length(mfrow.in)]))
   } else {
-    par(mfrow = c(length(bio_strat) / 2, 2))
+    par(mfrow = c(max(length(bio_strat)/2, 1), 2))
   }
 
   for (a in 1:length(bio_strat)) {


### PR DESCRIPTION
PlotBioStrata.fn now exits gracefully when only one strata exists. Previous functionality would throw an error when used with one strata, which was inhibiting generalized cross-survey analyses where different numbers of strata were being used.