### PR TITLE
Documentation fixes & option to not rescale comps to sum to 100

### DIFF
--- a/R/PullCatch.fn.R
+++ b/R/PullCatch.fn.R
@@ -45,6 +45,7 @@
 #'   * NWFSC.Santa.Barb.Basin,
 #'   * NWFSC.Shelf.Rockfish (NWFSC.Hook.Line but both are not working),
 #'   * NWFSC.Video.
+#' 
 #' Currently, you must pull data one survey at a time, though we are working on
 #' allowing for a vector of survey names and
 #' `NWFSC.Shelf.Rockfish` and `NWFSC.Hook.Line` are not supported.

--- a/R/StrataAreas.fn.R
+++ b/R/StrataAreas.fn.R
@@ -9,7 +9,9 @@
 #' 183, 200, 250, 300, 350, 400, 450, 500, 549, 600, 700, 800, 900, 1000,
 #' 1100, 1200, 1280), where the unevenly spaced values are due to depth
 #' boundaries associated with the strata used in the survey sampling design.
-#'
+#' A latitude break at 40.166667 has also been added to allow strata split
+#' at that common management boundary near Cape Mendocino.
+#' 
 #' @examples
 #' areaexample <- StrataAreas.fn(data.frame(
 #'   name = LETTERS[1:8],

--- a/R/SurveyLFs.fn.R
+++ b/R/SurveyLFs.fn.R
@@ -27,6 +27,7 @@
 #' @param printfolder folder where the length comps will be saved
 #' @param remove999 the output object by the function will have the 999 column combined with the first length bin
 #' @param outputStage1 TRUE/FALSE return the first stage expanded data without compiling it for SS
+#' @param sum100 A logical value specifying whether to rescale the compositions to sum to 100
 #' @template verbose
 #'
 #' @author Allan Hicks and Chantel Wetzel
@@ -37,7 +38,7 @@
 SurveyLFs.fn <- function(dir = NULL, datL, datTows, strat.vars = c("Depth_m", "Latitude_dd"), strat.df = NULL, lgthBins = 1, SSout = TRUE, meanRatioMethod = TRUE,
                          sex = 3, NAs2zero = T, sexRatioUnsexed = NA, maxSizeUnsexed = NA, sexRatioStage = 1, partition = 0, fleet = "Enter Fleet",
                          agelow = "Enter", agehigh = "Enter", ageErr = "Enter", nSamps = "Enter Samps", month = "Enter Month", printfolder = "forSS",
-                         remove999 = TRUE, outputStage1 = FALSE, verbose = TRUE) {
+                         remove999 = TRUE, outputStage1 = FALSE, sum100 = TRUE, verbose = TRUE) {
 
   # Check for the number of tows were fish were observed but not measured
   postows <- datTows[which(datTows$total_catch_numbers > 0), ]
@@ -345,10 +346,17 @@ SurveyLFs.fn <- function(dir = NULL, datL, datTows, strat.vars = c("Depth_m", "L
       TotalLjM = rep(NA, length(Lengths)), TotalLjU = rep(NA, length(Lengths))
     )
     row.names(out) <- out$Length
-    out[names(TotalLjAll), "TotalLjAll"] <- 100 * TotalLjAll / sum(TotalLjAll, na.rm = T)
-    out[names(TotalLjF), "TotalLjF"] <- 100 * TotalLjF / (sum(TotalLjF, na.rm = T) + sum(TotalLjM, na.rm = T))
-    out[names(TotalLjM), "TotalLjM"] <- 100 * TotalLjM / (sum(TotalLjF, na.rm = T) + sum(TotalLjM, na.rm = T))
-    out[names(TotalLjU), "TotalLjU"] <- 100 * TotalLjU / (sum(TotalLjU, na.rm = T))
+    if (sum100) {
+      out[names(TotalLjAll), "TotalLjAll"] <- 100 * TotalLjAll / sum(TotalLjAll, na.rm = T)
+      out[names(TotalLjF), "TotalLjF"] <- 100 * TotalLjF / (sum(TotalLjF, na.rm = T) + sum(TotalLjM, na.rm = T))
+      out[names(TotalLjM), "TotalLjM"] <- 100 * TotalLjM / (sum(TotalLjF, na.rm = T) + sum(TotalLjM, na.rm = T))
+      out[names(TotalLjU), "TotalLjU"] <- 100 * TotalLjU / (sum(TotalLjU, na.rm = T))
+    } else {
+      out[names(TotalLjAll), "TotalLjAll"] <- TotalLjAll
+      out[names(TotalLjF), "TotalLjF"] <- TotalLjF
+      out[names(TotalLjM), "TotalLjM"] <- TotalLjM
+      out[names(TotalLjU), "TotalLjU"] <- TotalLjU
+    }
     out <- out[-nrow(out), ] # remove last row because Inf and always NA due to inside.all=T
     return(out)
   }

--- a/man-roxygen/survey.R
+++ b/man-roxygen/survey.R
@@ -9,11 +9,12 @@
 #'   * NWFSC.Santa.Barb.Basin,
 #'   * NWFSC.Shelf.Rockfish (NWFSC.Hook.Line but both are not working),
 #'   * NWFSC.Video.
+#' 
 #' The National Marine Fishery Service Alaska Fisheries Science Center (AFSC)
 #' Triennial survey was conducted between 1977 - 2004 occurring every 3rd year.
 #' The initial year, 1977, survey is not traditionally used in calculating 
 #' The AFSC Slope Survey (AFSC.Slope) along the west coast of the U.S. began in 1984 and occurred 
-#' annually from 1988–2001, with the exception of 1994 and 1998, when surveys were not conducted. 
+#' annually from 1988-2001, with the exception of 1994 and 1998, when surveys were not conducted. 
 #' Prior to 1997, only a limited portion of the coast was covered in each year. 
 #' U.S. West Coast groundfish stock assessments only use the four years of consistent 
 #' and complete survey coverage (1997, 1999-2001). The Northwest Fisheries Science

--- a/man/PullCatch.fn.Rd
+++ b/man/PullCatch.fn.Rd
@@ -44,11 +44,12 @@ specifies which survey to pull the data for:
 \item NWFSC.Santa.Barb.Basin,
 \item NWFSC.Shelf.Rockfish (NWFSC.Hook.Line but both are not working),
 \item NWFSC.Video.
+}
+
 Currently, you must pull data one survey at a time, though we are working on
 allowing for a vector of survey names and
 \code{NWFSC.Shelf.Rockfish} and \code{NWFSC.Hook.Line} are not supported.
-The default of \code{NULL} is a placeholder that must be replaced with an entry.
-}}
+The default of \code{NULL} is a placeholder that must be replaced with an entry.}
 
 \item{SaveFile}{A logical value specifying whether or not the the data should
 be saved to a file in \code{Dir}. Must change from the default of \code{FALSE} to save a file.}

--- a/man/StrataAreas.fn.Rd
+++ b/man/StrataAreas.fn.Rd
@@ -37,6 +37,8 @@ depth breaks must be from the set (55, 75, 100, 125, 155,
 183, 200, 250, 300, 350, 400, 450, 500, 549, 600, 700, 800, 900, 1000,
 1100, 1200, 1280), where the unevenly spaced values are due to depth
 boundaries associated with the strata used in the survey sampling design.
+A latitude break at 40.166667 has also been added to allow strata split
+at that common management boundary near Cape Mendocino.
 }
 \examples{
 areaexample <- StrataAreas.fn(data.frame(

--- a/man/SurveyLFs.fn.Rd
+++ b/man/SurveyLFs.fn.Rd
@@ -32,6 +32,7 @@ SurveyLFs.fn(
   printfolder = "forSS",
   remove999 = TRUE,
   outputStage1 = FALSE,
+  sum100 = TRUE,
   verbose = TRUE
 )
 }
@@ -81,6 +82,8 @@ SurveyLFs.fn(
 \item{remove999}{the output object by the function will have the 999 column combined with the first length bin}
 
 \item{outputStage1}{TRUE/FALSE return the first stage expanded data without compiling it for SS}
+
+\item{sum100}{A logical value specifying whether to rescale the compositions to sum to 100}
 
 \item{verbose}{A logical that specifies if you want to print messages and
 warnings to the console. The default is \code{TRUE}.}

--- a/man/check_survey.Rd
+++ b/man/check_survey.Rd
@@ -19,11 +19,13 @@ specifies which survey to pull the data for. The input options are:
 \item NWFSC.Santa.Barb.Basin,
 \item NWFSC.Shelf.Rockfish (NWFSC.Hook.Line but both are not working),
 \item NWFSC.Video.
+}
+
 The National Marine Fishery Service Alaska Fisheries Science Center (AFSC)
 Triennial survey was conducted between 1977 - 2004 occurring every 3rd year.
 The initial year, 1977, survey is not traditionally used in calculating
 The AFSC Slope Survey (AFSC.Slope) along the west coast of the U.S. began in 1984 and occurred
-annually from 1988–2001, with the exception of 1994 and 1998, when surveys were not conducted.
+annually from 1988-2001, with the exception of 1994 and 1998, when surveys were not conducted.
 Prior to 1997, only a limited portion of the coast was covered in each year.
 U.S. West Coast groundfish stock assessments only use the four years of consistent
 and complete survey coverage (1997, 1999-2001). The Northwest Fisheries Science
@@ -34,8 +36,7 @@ shelf and slope between 55 - 1,280 meters.
 Data can only be pulled from one survey at a time, though we are working on
 allowing for a vector of survey names.
 Currently, \code{NWFSC.Shelf.Rockfish} and \code{NWFSC.Hook.Line} are not supported.
-The default of \code{NULL} is a placeholder that must be replaced with an entry.
-}}
+The default of \code{NULL} is a placeholder that must be replaced with an entry.}
 }
 \description{
 Check and create survey string

--- a/man/pull_bio.Rd
+++ b/man/pull_bio.Rd
@@ -47,11 +47,13 @@ specifies which survey to pull the data for. The input options are:
 \item NWFSC.Santa.Barb.Basin,
 \item NWFSC.Shelf.Rockfish (NWFSC.Hook.Line but both are not working),
 \item NWFSC.Video.
+}
+
 The National Marine Fishery Service Alaska Fisheries Science Center (AFSC)
 Triennial survey was conducted between 1977 - 2004 occurring every 3rd year.
 The initial year, 1977, survey is not traditionally used in calculating
 The AFSC Slope Survey (AFSC.Slope) along the west coast of the U.S. began in 1984 and occurred
-annually from 1988–2001, with the exception of 1994 and 1998, when surveys were not conducted.
+annually from 1988-2001, with the exception of 1994 and 1998, when surveys were not conducted.
 Prior to 1997, only a limited portion of the coast was covered in each year.
 U.S. West Coast groundfish stock assessments only use the four years of consistent
 and complete survey coverage (1997, 1999-2001). The Northwest Fisheries Science
@@ -62,8 +64,7 @@ shelf and slope between 55 - 1,280 meters.
 Data can only be pulled from one survey at a time, though we are working on
 allowing for a vector of survey names.
 Currently, \code{NWFSC.Shelf.Rockfish} and \code{NWFSC.Hook.Line} are not supported.
-The default of \code{NULL} is a placeholder that must be replaced with an entry.
-}}
+The default of \code{NULL} is a placeholder that must be replaced with an entry.}
 
 \item{dir}{directory where ouptut will be saved. The directory where the file should be saved.
 If dir = NULL no output will be saved.}

--- a/man/pull_biological_samples.Rd
+++ b/man/pull_biological_samples.Rd
@@ -49,11 +49,13 @@ specifies which survey to pull the data for. The input options are:
 \item NWFSC.Santa.Barb.Basin,
 \item NWFSC.Shelf.Rockfish (NWFSC.Hook.Line but both are not working),
 \item NWFSC.Video.
+}
+
 The National Marine Fishery Service Alaska Fisheries Science Center (AFSC)
 Triennial survey was conducted between 1977 - 2004 occurring every 3rd year.
 The initial year, 1977, survey is not traditionally used in calculating
 The AFSC Slope Survey (AFSC.Slope) along the west coast of the U.S. began in 1984 and occurred
-annually from 1988–2001, with the exception of 1994 and 1998, when surveys were not conducted.
+annually from 1988-2001, with the exception of 1994 and 1998, when surveys were not conducted.
 Prior to 1997, only a limited portion of the coast was covered in each year.
 U.S. West Coast groundfish stock assessments only use the four years of consistent
 and complete survey coverage (1997, 1999-2001). The Northwest Fisheries Science
@@ -64,8 +66,7 @@ shelf and slope between 55 - 1,280 meters.
 Data can only be pulled from one survey at a time, though we are working on
 allowing for a vector of survey names.
 Currently, \code{NWFSC.Shelf.Rockfish} and \code{NWFSC.Hook.Line} are not supported.
-The default of \code{NULL} is a placeholder that must be replaced with an entry.
-}}
+The default of \code{NULL} is a placeholder that must be replaced with an entry.}
 
 \item{dir}{directory where ouptut will be saved. The directory where the file should be saved.
 If dir = NULL no output will be saved.}

--- a/man/pull_catch.Rd
+++ b/man/pull_catch.Rd
@@ -44,11 +44,13 @@ specifies which survey to pull the data for. The input options are:
 \item NWFSC.Santa.Barb.Basin,
 \item NWFSC.Shelf.Rockfish (NWFSC.Hook.Line but both are not working),
 \item NWFSC.Video.
+}
+
 The National Marine Fishery Service Alaska Fisheries Science Center (AFSC)
 Triennial survey was conducted between 1977 - 2004 occurring every 3rd year.
 The initial year, 1977, survey is not traditionally used in calculating
 The AFSC Slope Survey (AFSC.Slope) along the west coast of the U.S. began in 1984 and occurred
-annually from 1988–2001, with the exception of 1994 and 1998, when surveys were not conducted.
+annually from 1988-2001, with the exception of 1994 and 1998, when surveys were not conducted.
 Prior to 1997, only a limited portion of the coast was covered in each year.
 U.S. West Coast groundfish stock assessments only use the four years of consistent
 and complete survey coverage (1997, 1999-2001). The Northwest Fisheries Science
@@ -59,8 +61,7 @@ shelf and slope between 55 - 1,280 meters.
 Data can only be pulled from one survey at a time, though we are working on
 allowing for a vector of survey names.
 Currently, \code{NWFSC.Shelf.Rockfish} and \code{NWFSC.Hook.Line} are not supported.
-The default of \code{NULL} is a placeholder that must be replaced with an entry.
-}}
+The default of \code{NULL} is a placeholder that must be replaced with an entry.}
 
 \item{dir}{directory where ouptut will be saved. The directory where the file should be saved.
 If dir = NULL no output will be saved.}

--- a/man/pull_haul.Rd
+++ b/man/pull_haul.Rd
@@ -24,11 +24,13 @@ specifies which survey to pull the data for. The input options are:
 \item NWFSC.Santa.Barb.Basin,
 \item NWFSC.Shelf.Rockfish (NWFSC.Hook.Line but both are not working),
 \item NWFSC.Video.
+}
+
 The National Marine Fishery Service Alaska Fisheries Science Center (AFSC)
 Triennial survey was conducted between 1977 - 2004 occurring every 3rd year.
 The initial year, 1977, survey is not traditionally used in calculating
 The AFSC Slope Survey (AFSC.Slope) along the west coast of the U.S. began in 1984 and occurred
-annually from 1988–2001, with the exception of 1994 and 1998, when surveys were not conducted.
+annually from 1988-2001, with the exception of 1994 and 1998, when surveys were not conducted.
 Prior to 1997, only a limited portion of the coast was covered in each year.
 U.S. West Coast groundfish stock assessments only use the four years of consistent
 and complete survey coverage (1997, 1999-2001). The Northwest Fisheries Science
@@ -39,8 +41,7 @@ shelf and slope between 55 - 1,280 meters.
 Data can only be pulled from one survey at a time, though we are working on
 allowing for a vector of survey names.
 Currently, \code{NWFSC.Shelf.Rockfish} and \code{NWFSC.Hook.Line} are not supported.
-The default of \code{NULL} is a placeholder that must be replaced with an entry.
-}}
+The default of \code{NULL} is a placeholder that must be replaced with an entry.}
 
 \item{dir}{directory where ouptut will be saved. The directory where the file should be saved.
 If dir = NULL no output will be saved.}

--- a/vignettes/nwfscSurvey.Rmd
+++ b/vignettes/nwfscSurvey.Rmd
@@ -147,7 +147,7 @@ len_bins <- seq(10, 60, 2)
 Length_Freq <- SurveyLFs.fn(dir = getwd(), 
                         datL =  bio, 
                         datTows = catch,
-                        strata.df = strata,
+                        strat.df = strata,
                         lgthBins = len_bins)
 ```
 The above call will calculate the length frequencies for use in Stock Synthesis and write the files inside the "forSS" folder. The example call does not assign unsexed fish to the sexed length comps but will produce csv files for both the sexed and unsexed fish. If you would like to assign the unsexed fish to a sex based on the sex ratio the user will need to specificy the sex ratio value (sexRatioUnsexed) to use for fish under a specified size (maxSizeUnsexed) where unsexed fish greater than the specified size will be assign based on the sex ratio from other observations. 
@@ -208,7 +208,7 @@ To calculate conditional-age-at-length data formatted for Stock Synthesis:
 caal <- SurveyAgeAtLen.fn(dir = getwd(), 
                           datAL = bio, 
                           datTows = catch,
-                          strata.df = strata,
+                          strat.df = strata,
                           lgthBins = len.bins, 
                           ageBins = age.bins)
 ```


### PR DESCRIPTION
This pull request mixes two issues. @chantelwetzel-noaa, let me know if you would like me to separate them.

There are three commits related to improving the documentation and then a fourth commit adding a new `sum100` argument to `SurveyLFs.fn()`. This is similar to the `sum1` input to `PacFIN.Utilities::writeComps()`: https://github.com/pfmc-assessments/PacFIN.Utilities/blob/main/R/writeComps.R#L49-L50 (where our code has been rescaling commercial comps to sum to 1.0 and survey comps to sum to 100 for no good reason since Stock Synthesis rescales them internally regardless). If we DON'T rescale the comps then it's possible to look at the estimated total amount of fish of different sizes as shown in the figure below for petrale.
![plot](https://user-images.githubusercontent.com/4992918/226481631-f5f7e727-13ac-4f95-b542-a7d3e2652c7b.png)
