### PR TITLE
Add R-CMD-check hourly

### DIFF
--- a/.github/workflows/R-CMD-check-hourly.yml
+++ b/.github/workflows/R-CMD-check-hourly.yml
@@ -1,0 +1,9 @@
+on:
+  workflow_dispatch:
+  schedule:
+      # Run every hour to test pulling from data warehouse
+      - cron: '0 */1 * * *'
+name: call-r-cmd-check
+jobs:
+  call-workflow:
+    uses: nmfs-fish-tools/ghactions4r/.github/workflows/r-cmd-check.yml@main


### PR DESCRIPTION
Currently ghactions4r only allows 6 OS or 3 OS. This is using the simple 3 OS so it will run the R-CMD-Check every hour. I did not change the existing workflow time schedule b/c eventually I would like to be able to change this workflow to just use on OS instead of the default 3 but that requires a change in ghactions4r.

I could delete line 2 that allows this workflow to run on dispatch because it is the exact same as the other workflow but it is not hurting anything.

@chantelwetzel-noaa let me know if you want to wait to merge this in until ghactions4r allows just one operating system or if I should change it to just use one OS manually, which would require using the r-lib actions rather than ghactions4r.