### PR TITLE
Fix biological data pull for Triennial and AFSC.Slope if no otoliths were collected

### DIFF
--- a/R/get_json.R
+++ b/R/get_json.R
@@ -20,13 +20,5 @@ get_json <- function(url) {
     httr::content(as = "text", encoding = "UTF-8") |>
     jsonlite::fromJSON()
 
-  if (!(is.data.frame(out) && NROW(out) > 0)) {
-    stop(glue::glue(
-      "\n No data returned by the warehouse for the filters given.
-      \n Make sure the year range is correct (cannot include -Inf or Inf) for the project selected and the input name is correct,
-      \n otherwise there may be no data for this species from this project.\n
-      URL: {url}"
-    ))
-  }
   return(out)
 }

--- a/R/pull_bio.R
+++ b/R/pull_bio.R
@@ -124,6 +124,15 @@ pull_bio <- function(
   }
   bio_pull <- try(get_json(url = url_text))
 
+  if (!(is.data.frame(bio_pull))) {
+    stop(glue::glue(
+      "\n No data returned by the warehouse for the filters given.
+      \n Make sure the year range is correct (cannot include -Inf or Inf) for the project selected and the input name is correct,
+      \n otherwise there may be no data for this species from this project.\n
+      URL: {url_text}"
+    ))
+  }
+
   if (!is.data.frame(bio_pull) & !survey %in% c("Triennial", "AFSC.Slope")) {
     stop(cat("\nNo data returned by the warehouse for the filters given.
             Make sure the year range is correct for the project selected and the input name is correct,

--- a/R/pull_bio.R
+++ b/R/pull_bio.R
@@ -67,7 +67,6 @@ pull_bio <- function(
          \n Please retry using only one.")
   }
 
-
   check_dir(dir = dir, verbose = verbose)
 
   if (is.null(common_name)) {
@@ -194,7 +193,7 @@ pull_bio <- function(
     )
     len_pull <- try(get_json(url = url_text))
 
-    if (!(is.data.frame(len_pull))) {
+    if (is.null(dim(len_pull))) {
       cli::cli_abort(
         "\n No data returned by the warehouse for the filters given.
       \n Make sure the year range is correct (cannot include -Inf or Inf) for the project selected and the input name is correct,

--- a/R/pull_bio.R
+++ b/R/pull_bio.R
@@ -194,6 +194,15 @@ pull_bio <- function(
     )
     len_pull <- try(get_json(url = url_text))
 
+    if (!(is.data.frame(len_pull))) {
+      cli::cli_abort(
+        "\n No data returned by the warehouse for the filters given.
+      \n Make sure the year range is correct (cannot include -Inf or Inf) for the project selected and the input name is correct,
+      \n otherwise there may be no data for this species from this project.\n
+      URL: {url_text}"
+      )
+    }
+
     if (is.data.frame(len_pull)) {
       fill_in <- is.na(len_pull[, "operation_dim$legacy_performance_code"])
       if (sum(fill_in) > 0) {

--- a/R/pull_bio.R
+++ b/R/pull_bio.R
@@ -123,14 +123,12 @@ pull_bio <- function(
   }
   bio_pull <- try(get_json(url = url_text))
 
-  # This is.list check here is to proceed on for Triennial and AFSC.Slope
-  # surveys which may return an empty list for ages since age and length
-  # are pulled separately.
-  if (!(is.data.frame(bio_pull)) & !is.list(bio_pull)) {
+  if (!is.data.frame(bio_pull) & !survey %in% c("AFSC.Slope", "Triennial")) {
     cli::cli_abort(
-      "\n No data returned by the warehouse for the filters given.
-      \n Make sure the year range is correct (cannot include -Inf or Inf) for the project selected and the input name is correct,
-      \n otherwise there may be no data for this species from this project.\n
+      "No data returned by the warehouse for the filters given.
+      Make sure the year range is correct (cannot include -Inf or Inf) for the
+      project selected and the input name is correct, otherwise there may be no
+      data for this species from this project.
       URL: {url_text}"
     )
   }
@@ -195,10 +193,11 @@ pull_bio <- function(
 
     if (is.null(dim(len_pull))) {
       cli::cli_abort(
-        "\n No data returned by the warehouse for the filters given.
-      \n Make sure the year range is correct (cannot include -Inf or Inf) for the project selected and the input name is correct,
-      \n otherwise there may be no data for this species from this project.\n
-      URL: {url_text}"
+        "len_pull: No data returned by the warehouse for the filters given.
+        Make sure the year range is correct (cannot include -Inf or Inf) for the
+        project selected and the input name is correct,otherwise there may be no
+        data for this species from this project.
+        URL: {url_text}"
       )
     }
 
@@ -231,7 +230,9 @@ pull_bio <- function(
       bio$age_data <- "no_ages_available"
     }
     if (verbose) {
-      cli::cli_alert_info("Triennial & AFSC Slope data returned as a list: bio$length_data and bio$age_data\n")
+      cli::cli_alert_info(
+        "Triennial & AFSC Slope data returned as a list: bio$length_data and bio$age_data"
+      )
     }
   }
 

--- a/R/pull_bio.R
+++ b/R/pull_bio.R
@@ -144,36 +144,18 @@ pull_bio <- function(
     # Some early entries are NA for standard sample indicators. These should be retained.
     standard_lengths <- bio_pull[, "standard_survey_length_or_width_indicator"] %in% c(NA, "NA", "Standard Survey Length or Width")
     if (length(standard_lengths) != dim(bio_pull)[1]) {
-      if (verbose) {
-        n <- dim(bio_pull)[1] - length(standard_lengths)
-        cli::cli_alert_info(
-          "There were {n} lengths removed because the were not within the standard sampling protocal."
-        )
-      }
       bio_pull <- bio_pull[standard_lengths, ]
     }
 
     # Remove non-standard ages
     nonstandard_age <- which(bio_pull[, "standard_survey_age_indicator"] == "Not Standard Survey Age")
     if (length(nonstandard_age) > 0) {
-      if (verbose) {
-        n <- length(nonstandard_age)
-        cli::cli_alert_info(
-          "There were {n} ages removed because the were not within the standard sampling protocal."
-        )
-      }
       bio_pull[nonstandard_age, "age_years"] <- NA
     }
 
     # Remove non-standard weights
     nonstandard_wgt <- which(bio_pull[, "standard_survey_weight_indicator"] == "Not Standard Survey Weight")
     if (length(nonstandard_wgt) > 0) {
-      if (verbose) {
-        n <- length(nonstandard_wgt)
-        cli::cli_alert_info(
-          "There were {n} weights removed because there were not collected at a standard survey location."
-        )
-      }
       bio_pull[nonstandard_wgt, "weight_kg"] <- NA
     }
 
@@ -184,12 +166,6 @@ pull_bio <- function(
     # A value of 8 in the Triennial data indicates a water haul
     good_tows <- bio_pull[, "operation_dim$legacy_performance_code"] != 8
     if (sum(good_tows) != dim(bio_pull)[1]) {
-      if (verbose) {
-        n <- dim(bio_pull)[1] - sum(good_tows)
-        cli::cli_alert_info(
-          "There were {n} tows removed because they were determined to be water hauls (e.g., net not on the bottom)."
-        )
-      }
       bio_pull <- bio_pull[good_tows, ]
     }
     find <- colnames(bio_pull) == "ageing_laboratory_dim$laboratory"
@@ -263,7 +239,7 @@ pull_bio <- function(
       x
     }
     if (survey %in% c("Triennial", "AFSC.Slope")) {
-      if (!is.null(nrow(bio[["age_data"]]))) {
+      if (!is.null(nrow(bio[["length_data"]]))) {
         colnames(bio[["length_data"]]) <- firstup(colnames(bio[["length_data"]]))
       }
 

--- a/R/pull_bio.R
+++ b/R/pull_bio.R
@@ -124,7 +124,10 @@ pull_bio <- function(
   }
   bio_pull <- try(get_json(url = url_text))
 
-  if (!(is.data.frame(bio_pull)) | !is.list(bio_pull)) {
+  # This is.list check here is to proceed on for Triennial and AFSC.Slope
+  # surveys which may return an empty list for ages since age and length
+  # are pulled separately.
+  if (!(is.data.frame(bio_pull)) & !is.list(bio_pull)) {
     cli::cli_abort(
       "\n No data returned by the warehouse for the filters given.
       \n Make sure the year range is correct (cannot include -Inf or Inf) for the project selected and the input name is correct,

--- a/R/pull_bio.R
+++ b/R/pull_bio.R
@@ -202,12 +202,6 @@ pull_bio <- function(
       # Remove water hauls
       good_tows <- len_pull[, "operation_dim$legacy_performance_code"] != 8
       if (sum(good_tows) != dim(len_pull)[1]) {
-        if (verbose) {
-          n <- dim(len_pull)[1] - sum(good_tows)
-          cli::cli_alert_info(
-            "There were {n} tows removed because they were determined to be water hauls (e.g., net not on the bottom)."
-          )
-        }
         len_pull <- len_pull[good_tows, ]
       }
 

--- a/tests/testthat/test-codify_sex.R
+++ b/tests/testthat/test-codify_sex.R
@@ -6,7 +6,7 @@ test_that("AFSC Slope pull biological table of Pacific ocean perch sexes", {
     years = c(1910, 2020),
     survey = "AFSC.Slope"
   )
-  originaltable <- table(dat[["Lengths"]][["Sex"]])
+  originaltable <- table(dat[["length_data"]][["Sex"]])
   testthat::expect_equal(
     c(2395, 3126, 600), # Values calculated on 2022-11-10 by CRW
     as.numeric(originaltable)
@@ -14,12 +14,12 @@ test_that("AFSC Slope pull biological table of Pacific ocean perch sexes", {
   # Check that recoding doesn't do anything
   testthat::expect_equal(
     originaltable,
-    table(codify_sex(dat[["Lengths"]][["Sex"]]))
+    table(codify_sex(dat[["length_data"]][["Sex"]]))
   )
   # Check that exchanging the first two values, which are U, for NA
   # does not change the results b/c NA are coded to U
   testthat::expect_equal(
     originaltable,
-    table(codify_sex(c(NA, NA, dat[["Lengths"]][["Sex"]])[-(1:2)]))
+    table(codify_sex(c(NA, NA, dat[["length_data"]][["Sex"]])[-(1:2)]))
   )
 })

--- a/tests/testthat/test-data.R
+++ b/tests/testthat/test-data.R
@@ -149,6 +149,16 @@ test_that("pull_bio_triennial", {
   expect_is(dat, "list")
   expect_equal(nrow(dat[[1]]), 1596)
   expect_equal(nrow(dat[[2]]), 382)
+
+  dat <- pull_bio(
+    common_name = "quillback rockfish",
+    years = c(1980, 2004),
+    survey = "Triennial",
+    verbose = TRUE
+  )
+  expect_is(dat, "list")
+  expect_equal(nrow(dat[[1]]), 48)
+  expect_equal(dat[[2]], "no_ages_available")
 })
 
 test_that("pull_biological_samples", {


### PR DESCRIPTION
This pull request:
1. Switches to the cli package to produce error and informational text for users.
2. Moves the error message when no data are available from `get_json()` to `pull_bio()` since the main function `pull_bio()` is the function that should halt if these conditions are met.
3. Add additional conditional statements that allows the function to proceed for the Triennial and AFSC.Slope survey if no otoliths were collected for the species of interest.  
4. Change the names of items in the data list for the Triennial and AFSC.Slope to be lower case and more informative.
5. Clean up the covert conditional code to only convert column names. 

@brianlangseth-NOAA can you review these changes for the issues you were having?  Once you have reviewed the changes, I will coordinate merging this pull request into the main branch based on the other outstanding pull request #145. 