### PR TITLE
Minor vignette fixes

### DIFF
--- a/R/get_expanded_comps.R
+++ b/R/get_expanded_comps.R
@@ -124,6 +124,7 @@ get_expanded_comps <- function(
   colnames(bio_data) <- tolower(colnames(bio_data))
   colnames(catch_data) <- tolower(colnames(catch_data))
   colnames(strata) <- tolower(colnames(strata))
+  comp_column_name <- tolower(comp_column_name)
 
   species <- gsub(" ", "_", tolower(unique(bio_data[, "common_name"])))[1]
   project <- project <- gsub(" ", "_", tolower(unique(bio_data[, "project"])))
@@ -161,7 +162,6 @@ get_expanded_comps <- function(
   }
   # Put in row names to make easier to index later
   row.names(strata) <- strata[, 1]
-  comp_column_name <- tolower(comp_column_name)
 
   strata_vars <- c("depth_m", "latitude_dd")
   check_strata <- tolower(unique(gsub("\\..*", "", colnames(strata))))

--- a/vignettes/nwfscSurvey.Rmd
+++ b/vignettes/nwfscSurvey.Rmd
@@ -78,19 +78,22 @@ wh_plot_proportion(
 )
 ```
 
-#### Index of abundance
-Define the stratification by depth and latitude that will be used to calculate a design-based index of abundance:
+#### Define strata
+
+Depth and latitude strata are required to calculate a design-based index of abundance as well as length and age compositions. The strata should be specific to the range where the species in question has been observed. Note that the WCGBT Survey sampling design has changes in sampling intensity at 183 and 549 meters and north and south of 34.5 degrees latitude, so these should generally be included as strata breaks if the range spans these values. Pacific ocean perch are rarely observed south of 34.5 degrees or deeper than 540 m, so there's no need to include strata that have very few observations (the survey extends southward to about 32 degrees and as deep as 1280 m):
 
 ```r
 
-strata = CreateStrataDF.fn(
-  names = c("shallow_s", "mid_s", "deep_s", "shallow_n", "mid_n", "deep_n"), 
-  depths.shallow = c( 55,   200, 300,    55, 200, 300),
-  depths.deep    = c(200,   300, 400,   200, 300, 400),
-  lats.south     = c( 32,    32,  32,    42,  42,  42),
-  lats.north     = c( 42,    42,  42,    49,  49,  49))
-
+strata <- CreateStrataDF.fn(
+  names = c("shallow_s", "deep_s", "shallow_n", "deep_n"), 
+  depths.shallow = c(  55,  183,  55, 183),
+  depths.deep    = c( 183,  400, 183, 400),
+  lats.south     = c(34.5, 34.5,  42,  42),
+  lats.north     = c(  42,   42,  49,  49)
+)
 ```
+
+#### Index of abundance
 
 Calculate the design based index of abundance:
 
@@ -99,23 +102,8 @@ biomass = get_design_based(
   data = catch,  
   strata = strata)
 ```
-`get_design_based()` returns a list with the second element containing the design based index of abundance. The design based index is calculated based on the defined stratas. If the `dir` function input is specified, the function writes a csv file inside the dir input location to a "forSS3" folder. The function returns a list with the second element containing the design based estimates by year:
+`get_design_based()` returns a list with elements `$biomass_by_strata` and `$biomass`, where the second element is the design based index of abundance aggregated across strata. If the `dir` function input is specified, the function writes a csv file inside the dir input location to a "forSS3" folder.
 
-```{r, results = 'asis', echo = FALSE}
-library(xtable)
-library(kableExtra)
-
-tab <- rbind(
-  c(2003, 38888.94, 0.379, 18519.720, 81661.56),
-  c("...", "", ""),
-  c(2015, 22317.60, 0.135, 17135.936, 29066.13)
-)
-
-colnames(tab) <- c("year", "est", "se_log", "lwr", "upr")
-
-table <- tab
-kable(table, "html")
-```
 
 Plot the coastwide design based index of abundance with uncertainty intervals:
 ```r

--- a/vignettes/nwfscSurvey.Rmd
+++ b/vignettes/nwfscSurvey.Rmd
@@ -99,7 +99,7 @@ biomass = get_design_based(
   data = catch,  
   strata = strata)
 ```
-`get_design_based()` returns a list with the second element containing the design based index of abundance. The design based index is calculated based on the defined stratas. The function writes a csv file inside the dir input location to a "forSS3" folder. The function returns a list with the second element containing the design based estimates by year:
+`get_design_based()` returns a list with the second element containing the design based index of abundance. The design based index is calculated based on the defined stratas. If the `dir` function input is specified, the function writes a csv file inside the dir input location to a "forSS3" folder. The function returns a list with the second element containing the design based estimates by year:
 
 ```{r, results = 'asis', echo = FALSE}
 library(xtable)
@@ -145,7 +145,7 @@ length_comps <- get_expanded_comps(
     two_sex_comps = TRUE,
     input_n_method = "stewart_hamel")
 ```
-The above call will calculate the length frequencies for use in Stock Synthesis and write the files inside the "forSS3" folder. The example call will produce csv files for both the sexed and unsexed fish. This function returns a list of sexed and unsexed length composition data formatted for Stock Synthesis. In the above example the input sample size is calculated based on the Stewart and Hamel approach (e.g., unique samples calculated as a function of species type and tows).
+The above call will calculate the length frequencies for use in Stock Synthesis. This function returns a list of sexed and unsexed length composition data formatted for Stock Synthesis. If the `dir` function input is specified, it will write these dataframes to separate csv files inside the dir input location to a "forSS3" folder. In the above example the input sample size is calculated based on the Stewart and Hamel approach (e.g., unique samples calculated as a function of species type and tows).
 
 To plot the length frequency data:
 ```r
@@ -176,12 +176,12 @@ age_comps <- get_expanded_comps(
     catch_data = catch,
     comp_bins = 1:40,
     strata = strata,
-    comp_column_name = "length_cm",
+    comp_column_name = "age",
     output = "full_expansion_ss3_format",
     two_sex_comps = TRUE,
     input_n_method = "stewart_hamel")
 ```
-The above call will calculate the marginal age-composition data for the age data in a format for Stock Synthesis. This function returns a list of sexed and unsexed marginal age composition data formatted for Stock Synthesis. The example call will produce csv files for both the sexed and unsexed fish. This function returns a list of sexed and unsexed length composition data formatted for Stock Synthesis. In the above example the input sample size is calculated based on the Stewart and Hamel approach (e.g., unique samples calculated as a function of species type and tows). 
+The above call will calculate the marginal age-composition data for the age data in a format for Stock Synthesis. This function returns a list of sexed and unsexed age composition data formatted for Stock Synthesis. If the `dir` function input is specified, it will write these dataframes to separate csv files as well. In the above example the input sample size is calculated based on the Stewart and Hamel approach (e.g., unique samples calculated as a function of species type and tows). 
 
 To plot the age frequency data:
 ```r
@@ -213,7 +213,7 @@ caal <- SurveyAgeAtLen.fn(
   lgthBins = seq(10, 40, 2), 
   ageBins = 1:40)
 ```
-Creates unexpanded conditional-age-at-length data for both sexes with input sample sizes based on the observed number of fish in each length bin by year.
+Creates unexpanded conditional-age-at-length data for each sex with input sample sizes based on the observed number of fish in each length bin by year. It returns a list of three dataframes: "female", "male", and "unsexed". If the `dir` function input is specified, it will write these dataframes to separate csv files as well.
 
 #### Maps
 


### PR DESCRIPTION
This Pull Request does a few things:
1. fixes a copy/paste typo which had the age comps referencing "length_cm" instead of "age". 
2. allows both "age" and "Age" to work as `comp_column_name`
3. clarifies some text in the vignette related to writing CSV files
4. changes the example strata to include breaks in sampling intensity in the survey design and adds description of those breaks
5. removes the example table extract of design-based results

Regarding number 5, I tried just updating the table, which was out of date even with the old strata, to be dynamic based on the code using the commands below, but this required extensive changes to the vignette to actually run several of the code chunks above instead of just printing the code which then resulting in lots of plots being added to the vignette in a distracting way that I don't have time to explore further. Removing the table was faster and doesn't have much impact on the utility of the vignette.
```
# round columns for printing smaller version of the table
tab <- biomass$biomass |> 
  dplyr::mutate_at(c(2,4,5), round, 1) |> 
  dplyr::mutate_at(3, round, 4)
# remove most rows and replace with "..."
tab <- rbind(
  head(tab, 2), 
  c("...", rep("", 4)), 
  tail(tab, 1)
)
kableExtra::kable(tab, "html")
```
