### PR TITLE
Fixes to plot_cpue

### DIFF
--- a/R/plot_cpue.R
+++ b/R/plot_cpue.R
@@ -2,11 +2,18 @@
 #'
 #' @template dir
 #' @param catch Data catch file pulled using [pull_catch()]
-#' @param plot A vector of integers specifying the figures you want.
-#' @param ... additional arguments to [ggsave()]. Figure width and height default to 7 in.
+#' @param plot A vector of integers specifying the figures you want. See 'Details' for options.
+#' @param ... Additional arguments to [ggsave()]. Figure width and height default to 7 in.
 #'
 #' @import ggplot2
 #' @import cowplot
+#'
+#' @details
+#' Plots produced:
+#' 1. Marginal log(CPUE) by depth and latitude
+#' 2. log(CPUE) by latitude and year
+#' 3. log(CPUE) by depth and year
+#'
 #'
 #' @author Chantel Wetzel
 #' @export
@@ -25,10 +32,11 @@ plot_cpue <- function(
   size_adj <- 100 / floor(sum(pos))
 
   # ggsave arguments
-  l <- list(...)
+  l <- as.list(substitute(...()))
   if (is.null(l$width)) l$width <- 7
   if (is.null(l$height)) l$height <- 7
   if (is.null(l$units)) l$units <- "in"
+  if (is.null(l$device)) l$device <- "png" else l$device <- gsub("[^[:alnum:] ]", "", deparse(l$device))
 
   # plot 1 - marginal log(cpue) by depth and latitude
   if (1 %in% plot) {
@@ -73,7 +81,7 @@ plot_cpue <- function(
     # plot 1
     print(cowplot::plot_grid(cl, cd, nrow = 2))
     if (!is.null(dir)) {
-      l$filename <- file.path(dir, "plots", "cpue_by_lat_depth.png")
+      l$filename <- file.path(dir, "plots", paste0("cpue_by_lat_depth.", l$device))
       do.call(ggsave, l)
     }
 
@@ -95,7 +103,7 @@ plot_cpue <- function(
 
     print(cly)
     if (!is.null(dir)) {
-      l$filename <- file.path(dir, "plots", "cpue_by_year_lat.png")
+      l$filename <- file.path(dir, "plots", paste0("cpue_by_year_lat.", l$device))
       l2 <- l; l2$width <- l2$width + 3; l2$height <- l2$height + 3
       do.call(ggsave, l2)
     }
@@ -118,7 +126,7 @@ plot_cpue <- function(
 
     print(cdy)
     if (!is.null(dir)) {
-      l$filename <- file.path(dir, "plots", "cpue_by_year_depth.png")
+      l$filename <- file.path(dir, "plots", paste0("cpue_by_year_depth.", l$device))
       l2 <- l; l2$width <- l2$width + 3; l2$height <- l2$height + 3
       do.call(ggsave, l2)
     }

--- a/R/plot_cpue.R
+++ b/R/plot_cpue.R
@@ -2,18 +2,18 @@
 #'
 #' @template dir
 #' @param catch Data catch file pulled using [pull_catch()]
-#' @param plot A vector of integers specifying the figures you want. See 'Details' for options.
-#' @param ... Additional arguments to [ggsave()]. Figure width and height default to 7 in.
+#' @param plot A vector of integers to specify which plots to return. The
+#'   default is to print or save all figures, i.e., `plot = 1:3`. Integers
+#'   correspond to the following figures:
+#'   1. log(CPUE) by depth & log(CPUE) by latitude
+#'   2. log(CPUE) by latitude and year
+#'   3. log(CPUE) by depth and year
+#' @param width,height Numeric values for the figure width and height in
+#'   inches. The defaults are 7 by 7 inches.
+#' @param ... Additional arguments to [ggsave()]
 #'
 #' @import ggplot2
 #' @import cowplot
-#'
-#' @details
-#' Plots produced:
-#' 1. Marginal log(CPUE) by depth and latitude
-#' 2. log(CPUE) by latitude and year
-#' 3. log(CPUE) by depth and year
-#'
 #'
 #' @author Chantel Wetzel
 #' @export
@@ -22,6 +22,8 @@ plot_cpue <- function(
     catch,
     dir = NULL,
     plot = 1:3,
+    width = 7,
+    height = 7,
     ...) {
 
   plotdir <- file.path(dir, "plots")
@@ -33,8 +35,8 @@ plot_cpue <- function(
 
   # ggsave arguments
   l <- as.list(substitute(...()))
-  if (is.null(l$width)) l$width <- 7
-  if (is.null(l$height)) l$height <- 7
+  l$width <- width
+  l$height <- height
   if (is.null(l$units)) l$units <- "in"
   if (is.null(l$device)) l$device <- "png" else l$device <- gsub("[^[:alnum:] ]", "", deparse(l$device))
 

--- a/man/plot_cpue.Rd
+++ b/man/plot_cpue.Rd
@@ -12,12 +12,20 @@ plot_cpue(catch, dir = NULL, plot = 1:3, ...)
 \item{dir}{Directory where output will be saved. The directory where the file should be saved.
 If dir = NULL no output will be saved.}
 
-\item{plot}{A vector of integers specifying the figures you want.}
+\item{plot}{A vector of integers specifying the figures you want. See 'Details' for options.}
 
-\item{...}{additional arguments to \code{\link[=ggsave]{ggsave()}}. Figure width and height default to 7 in.}
+\item{...}{Additional arguments to \code{\link[=ggsave]{ggsave()}}. Figure width and height default to 7 in.}
 }
 \description{
 This function plots cpue and length by latitude and depth
+}
+\details{
+Plots produced:
+\enumerate{
+\item Marginal log(CPUE) by depth and latitude
+\item log(CPUE) by latitude and year
+\item log(CPUE) by depth and year
+}
 }
 \author{
 Chantel Wetzel

--- a/man/plot_cpue.Rd
+++ b/man/plot_cpue.Rd
@@ -4,19 +4,17 @@
 \alias{plot_cpue}
 \title{This function plots cpue and length by latitude and depth}
 \usage{
-plot_cpue(dir = NULL, catch, plot = 1:3, width = 7, height = 7)
+plot_cpue(catch, dir = NULL, plot = 1:3, ...)
 }
 \arguments{
+\item{catch}{Data catch file pulled using \code{\link[=pull_catch]{pull_catch()}}}
+
 \item{dir}{Directory where output will be saved. The directory where the file should be saved.
 If dir = NULL no output will be saved.}
 
-\item{catch}{Data catch file pulled using \code{\link[=pull_catch]{pull_catch()}}}
-
 \item{plot}{A vector of integers specifying the figures you want.}
 
-\item{width}{Numeric figure width in inches, defaults to 7}
-
-\item{height}{Numeric figure height in inches, defaults to 7}
+\item{...}{additional arguments to \code{\link[=ggsave]{ggsave()}}. Figure width and height default to 7 in.}
 }
 \description{
 This function plots cpue and length by latitude and depth

--- a/man/plot_cpue.Rd
+++ b/man/plot_cpue.Rd
@@ -4,7 +4,7 @@
 \alias{plot_cpue}
 \title{This function plots cpue and length by latitude and depth}
 \usage{
-plot_cpue(catch, dir = NULL, plot = 1:3, ...)
+plot_cpue(catch, dir = NULL, plot = 1:3, width = 7, height = 7, ...)
 }
 \arguments{
 \item{catch}{Data catch file pulled using \code{\link[=pull_catch]{pull_catch()}}}
@@ -12,20 +12,22 @@ plot_cpue(catch, dir = NULL, plot = 1:3, ...)
 \item{dir}{Directory where output will be saved. The directory where the file should be saved.
 If dir = NULL no output will be saved.}
 
-\item{plot}{A vector of integers specifying the figures you want. See 'Details' for options.}
+\item{plot}{A vector of integers to specify which plots to return. The
+default is to print or save all figures, i.e., \code{plot = 1:3}. Integers
+correspond to the following figures:
+\enumerate{
+\item log(CPUE) by depth & log(CPUE) by latitude
+\item log(CPUE) by latitude and year
+\item log(CPUE) by depth and year
+}}
 
-\item{...}{Additional arguments to \code{\link[=ggsave]{ggsave()}}. Figure width and height default to 7 in.}
+\item{width, height}{Numeric values for the figure width and height in
+inches. The defaults are 7 by 7 inches.}
+
+\item{...}{Additional arguments to \code{\link[=ggsave]{ggsave()}}}
 }
 \description{
 This function plots cpue and length by latitude and depth
-}
-\details{
-Plots produced:
-\enumerate{
-\item Marginal log(CPUE) by depth and latitude
-\item log(CPUE) by latitude and year
-\item log(CPUE) by depth and year
-}
 }
 \author{
 Chantel Wetzel


### PR DESCRIPTION
Fixes the following small errors in `plot_cpue`.

- `plot` argument ignored
- plot 1 (marginal log(cpue) by depth, latitude) not printed to console
- Error when catch passed as unnamed (first) argument

Also allows for additional arguments to `ggsave` (other than height and width), e.g. dpi, scaling, device.