### PR TITLE
update get_raw_comps for cases with zero samples

### DIFF
--- a/R/get_raw_comps.R
+++ b/R/get_raw_comps.R
@@ -207,7 +207,7 @@ get_raw_comps <- function(
       fleet = fleet,
       sex = 3,
       partition = partition,
-      input_n = samples |> dplyr::filter(sex_grouped == "sexed") |> dplyr::select(input_n) # Results[, 2]
+      input_n = samples |> dplyr::filter(sex_grouped == "sexed", input_n > 0) |> dplyr::select(input_n) # Results[, 2]
     )
     out <- cbind(tmp, Results[, -c(1:2)])
     colnames(out)[-c(1:6)] <- c(


### PR DESCRIPTION
I got an error when using `get_raw_comps()` because `get_input_n()` [includes rows with zero samples for a given sex group](https://github.com/pfmc-assessments/nwfscSurvey/blob/main/R/get_input_n.R#L123) whereas the loop that makes the `Results` matrix does not include such rows. This leads to a mismatch in dimensions [here](https://github.com/pfmc-assessments/nwfscSurvey/blob/main/R/get_raw_comps.R#L204-L211).

This commit fixes that mismatch by filtering out rows in `samples` with `input_n` of zero. 