### PR TITLE
fix for bug in get_expanded_comps() if no unsexed fish

### DIFF
--- a/R/get_expanded_comps.R
+++ b/R/get_expanded_comps.R
@@ -444,13 +444,19 @@ get_expanded_comps <- function(
       sexed_formatted <- sexed_formatted[-remove, ]
     }
 
+    input_n <- samples |> dplyr::filter(sex_grouped == "unsexed") |> dplyr::select(input_n)
+    # if there are no unsexed fish, input_n will be empty
+    if(nrow(input_n) == 0) {
+      input_n <- 0
+    }
+
     unsexed_formatted <- data.frame(
       year = unsexed_comps[, "year"],
       month = month,
       fleet = fleet,
       sex = 0,
       partition = partition,
-      input_n = samples |> dplyr::filter(sex_grouped == "unsexed") |> dplyr::select(input_n)
+      input_n = input_n
     )
     unsexed_comps_good <- unsexed_comps[, dimensions]
     placeholder_comps <- 0 * unsexed_comps[, dimensions]

--- a/R/get_raw_comps.R
+++ b/R/get_raw_comps.R
@@ -135,8 +135,11 @@ get_raw_comps <- function(
   if (!"common_name" %in% colnames(data) & input_n_method == "stewart_hamel") {
     cli::cli_abort(
       "Data frame does not contain a column name of common_name which is required
-      to calculate Stewart and Hamel input sample size. The columns names can be
-      either upper or lower case."
+      to calculate Stewart and Hamel input sample size. This method was developed based on
+      bootstrapping of trawl survey data and is generally only applied to trawl survey data
+      for West Coast groundfish assessments. If trying to calculate input sample size for
+      other data sources, please consider using either the input_n_method options of
+      tows (if that information is available) or total samples."
     )
   }
 

--- a/tests/testthat/test-comps.R
+++ b/tests/testthat/test-comps.R
@@ -58,6 +58,40 @@ test_that("get_raw_comps", {
   expect_equal(sum(age_comps$unsexed$input_n), sum(age_comps$unsexed[, 10:ncol(age_comps$unsexed)]))
 })
 
+test_that("get_raw_comps_triennial", {
+  skip_on_cran()
+
+  dat <- pull_bio(
+    common_name = "yellowtail rockfish",
+    years = c(1980, 2004),
+    survey = "Triennial",
+    verbose = TRUE
+  )
+  length_data <- dat$length_data |>
+    dplyr::filter(Sex != "U")
+
+  length_comps <- get_raw_comps(
+    data = length_data,
+    comp_bins = seq(20, 50, 2),
+    comp_column_name = "Length_cm",
+    two_sex_comps = TRUE,
+    input_n_method = "total_samples"
+  )
+  expect_equal(nrow(length_comps$sexed), 9)
+  expect_equal(sum(length_comps$sexed$input_n), sum(length_comps$sexed[, 7:ncol(length_comps$sexed)]))
+  expect_equal(nrow(length_comps$unsexed), 0)
+
+  length_unsexed_comps <- get_raw_comps(
+    data = length_data,
+    comp_bins = seq(20, 50, 2),
+    comp_column_name = "Length_cm",
+    two_sex_comps = FALSE,
+    input_n_method = "stewart_hamel"
+  )
+  expect_equal(nrow(length_unsexed_comps$unsexed), 9)
+  expect_equal(sum(length_unsexed_comps$unsexed$input_n), 8195)
+})
+
 
 test_that("get_raw_caal", {
   skip_on_cran()
@@ -122,6 +156,21 @@ test_that("get_expanded_comps", {
   expect_equal(sum(length_comps$sexed$input_n), 4883)
   expect_equal(nrow(length_comps$unsexed), 14)
   expect_equal(sum(length_comps$unsexed$input_n), 84)
+
+  length_comps_sexed <- get_expanded_comps(
+    bio_data = bio |> dplyr::filter(Sex != "U"),
+    catch_data = catch,
+    comp_bins = seq(14, 80, 4),
+    strata = strata,
+    comp_column_name = "length_cm",
+    two_sex_comps = TRUE,
+    output = "full_expansion_ss3_format",
+    input_n_method = "stewart_hamel",
+    verbose = FALSE
+  )
+  expect_equal(nrow(length_comps_sexed$sexed), 16)
+  expect_equal(sum(length_comps_sexed$sexed$input_n), 4883)
+  expect_equal(nrow(length_comps_sexed$unsexed), 0)
 
   # confirm that plot_comps works for expanded length comps
   comp_plot <- plot_comps(length_comps)

--- a/tests/testthat/test-comps.R
+++ b/tests/testthat/test-comps.R
@@ -79,7 +79,7 @@ test_that("get_raw_comps_triennial", {
   )
   expect_equal(nrow(length_comps$sexed), 9)
   expect_equal(sum(length_comps$sexed$input_n), sum(length_comps$sexed[, 7:ncol(length_comps$sexed)]))
-  expect_equal(nrow(length_comps$unsexed), 0)
+  expect_equal(nrow(length_comps$unsexed), NULL)
 
   length_unsexed_comps <- get_raw_comps(
     data = length_data,
@@ -89,7 +89,7 @@ test_that("get_raw_comps_triennial", {
     input_n_method = "stewart_hamel"
   )
   expect_equal(nrow(length_unsexed_comps$unsexed), 9)
-  expect_equal(sum(length_unsexed_comps$unsexed$input_n), 8195)
+  expect_equal(sum(length_unsexed_comps$unsexed$input_n), 1125)
 })
 
 


### PR DESCRIPTION
Fixes #180 by setting `input_n = 0` for unsexed fish to allow code to play through without error.

If there are no unsexed fish, the list returned by `get_expanded_comps()` will still include an $unsexed dataframe, but it will be empty as shown below. This seems preferable for generalized workflows than omitting that output entirely, but I'm happy to change if you want.

```
r$> tri_length_comps$unsexed
 [1] year      month     fleet     sex       partition input_n   u20       u22       u24       u26       u28       u30       u32       u34       u36       u38
[17] u40       u42       u44       u46       u48       u50       u52       u54       u56       u20       u22       u24       u26       u28       u30       u32
[33] u34       u36       u38       u40       u42       u44       u46       u48       u50       u52       u54       u56
<0 rows> (or 0-length row.names)
```