### PR TITLE
Add explanations for unexpanded comps

### DIFF
--- a/R/get_raw_comps.R
+++ b/R/get_raw_comps.R
@@ -10,10 +10,13 @@
 #' two-sex model or all length/ages for single-sex model.
 #'
 #' @inheritParams get_expanded_comps
-#' @param data A data frame that includes columns of year, sex, and length/ages. The data
+#' @param data A data frame that includes columns of year, sex, and length/ages. The case
+#'   of the column names does not matter as the function reduces them to lower case. The data
 #'   frame can be survey data pulled using pull_bio from the data warehouse or any data frame
-#'   that includes column names of sex, year, and the comp_column_name.  The sex column is
-#'   expected to have sexes denoted by F, M, and U.
+#'   that includes column names of sex, year, and the comp_column_name. The sex column is
+#'   expected to have sexes denoted by F, M, and U. If tows/trips are desired for `input_n_method`
+#'   and a column exists within the data frame with this information, the column needs to be named `trawl_id`,
+#'   otherwise the function will set a unique `trawl_id` for each record. 
 #' @param comp_column_name The column name to create composition data for. This column can be
 #'   is used to determine whether to format the composition data for length or age
 #'   compositions by looking for either age (e.g., `age_years`, `Age`, `best_age`) or length


### PR DESCRIPTION
This pull request adds minor documentation changes to increase clarity on the use of the function for unexpanded compositions (per pfmc-assessments/pacfintools#150).

These changes add 
1. specification that column name case does not matter
2. that Stewart and Hamel method requires a `common_name`, which was added within the script via commit 68f435a and described in #178
3. that if have a column with tow information, and `input_n_method` = tow, the column needs to be named “trawl_id”